### PR TITLE
fix: bad output path in generated file

### DIFF
--- a/cmd/goqu-crud-gen/main.go
+++ b/cmd/goqu-crud-gen/main.go
@@ -188,7 +188,7 @@ func main() {
 		sb.WriteString(" ")
 		sb.WriteString("-path")
 		sb.WriteString(" ")
-		sb.WriteString(*fPath)
+		sb.WriteString(".")
 
 		if *fRepo != "" {
 			sb.WriteString(" ")


### PR DESCRIPTION
Now `-path` in generated file always have "." value.