### PR TITLE
feat: generate repo.c like repo.f but with strings

### DIFF
--- a/cmd/goqu-crud-gen/repo_tpl.go
+++ b/cmd/goqu-crud-gen/repo_tpl.go
@@ -11,14 +11,23 @@ type (
 		dialectName string
 		options     RepositoryOpt
 
-		// short for "table"
+		// Short for "table".
 		t string
-		// short for "table fields"
+		// Short for "table fields", holds repository model fields as goqu exp.IdentifierExpression.
 		f {{ .Repo.Name|Private }}Fields
+		// Short for "table columns", holds repository model columns as string.
+		//
+		// Helps to write goqu.UpdateDataset with goqu.Record{}.
+		c {{ .Repo.Name|Private }}Columns
 	}
 	{{ .Repo.Name|Private }}Fields struct {
 		{{ range $field := .Model.Fields }}
 			{{- $field.Name }} exp.IdentifierExpression
+		{{ end }}
+	}
+	{{ .Repo.Name|Private }}Columns struct {
+		{{ range $field := .Model.Fields }}
+			{{- $field.Name }} string
 		{{ end }}
 	}
 )
@@ -42,6 +51,11 @@ func New{{ .Repo.Name }}(dsn string, opt...RepositoryOption) *{{ .Repo.Name }} {
 		f: {{ .Repo.Name|Private }}Fields{
 			{{ range $field := .Model.Fields }}
 				{{- $field.Name }}: goqu.C("{{ $field.ColName }}").Table(t),
+			{{ end }}
+		},
+		c: {{ .Repo.Name|Private }}Columns{
+			{{ range $field := .Model.Fields }}
+				{{- $field.Name }}: "{{ $field.ColName }}",
 			{{ end }}
 		},
 		options: RepositoryOpt{
@@ -70,6 +84,11 @@ func {{ .Repo.Name }}WithInstance(inst *sqlx.DB, opt...RepositoryOption) *{{ .Re
 		f: {{ .Repo.Name|Private }}Fields{
 			{{ range $field := .Model.Fields }}
 				{{- $field.Name }}: goqu.C("{{ $field.ColName }}").Table(t),
+			{{ end }}
+		},
+		c: {{ .Repo.Name|Private }}Columns{
+			{{ range $field := .Model.Fields }}
+				{{- $field.Name }}: "{{ $field.ColName }}",
 			{{ end }}
 		},
 		options: RepositoryOpt{

--- a/examples/example1/model/user_repo.go
+++ b/examples/example1/model/user_repo.go
@@ -22,15 +22,24 @@ type (
 		dialectName string
 		options     RepositoryOpt
 
-		// short for "table"
+		// Short for "table".
 		t string
-		// short for "table fields"
+		// Short for "table fields", holds repository model fields as goqu exp.IdentifierExpression.
 		f userRepoFields
+		// Short for "table columns", holds repository model columns as string.
+		//
+		// Helps to write goqu.UpdateDataset with goqu.Record{}.
+		c userRepoColumns
 	}
 	userRepoFields struct {
 		Id    exp.IdentifierExpression
 		Name  exp.IdentifierExpression
 		Email exp.IdentifierExpression
+	}
+	userRepoColumns struct {
+		Id    string
+		Name  string
+		Email string
 	}
 )
 
@@ -54,6 +63,11 @@ func NewUserRepo(dsn string, opt ...RepositoryOption) *UserRepo {
 			Id:    goqu.C("id").Table(t),
 			Name:  goqu.C("name").Table(t),
 			Email: goqu.C("email").Table(t),
+		},
+		c: userRepoColumns{
+			Id:    "id",
+			Name:  "name",
+			Email: "email",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,
@@ -82,6 +96,11 @@ func UserRepoWithInstance(inst *sqlx.DB, opt ...RepositoryOption) *UserRepo {
 			Id:    goqu.C("id").Table(t),
 			Name:  goqu.C("name").Table(t),
 			Email: goqu.C("email").Table(t),
+		},
+		c: userRepoColumns{
+			Id:    "id",
+			Name:  "name",
+			Email: "email",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,

--- a/examples/example2/user_repo.go
+++ b/examples/example2/user_repo.go
@@ -23,15 +23,24 @@ type (
 		dialectName string
 		options     RepositoryOpt
 
-		// short for "table"
+		// Short for "table".
 		t string
-		// short for "table fields"
+		// Short for "table fields", holds repository model fields as goqu exp.IdentifierExpression.
 		f userRepoFields
+		// Short for "table columns", holds repository model columns as string.
+		//
+		// Helps to write goqu.UpdateDataset with goqu.Record{}.
+		c userRepoColumns
 	}
 	userRepoFields struct {
 		Id    exp.IdentifierExpression
 		Name  exp.IdentifierExpression
 		Email exp.IdentifierExpression
+	}
+	userRepoColumns struct {
+		Id    string
+		Name  string
+		Email string
 	}
 )
 
@@ -55,6 +64,11 @@ func NewUserRepo(dsn string, opt ...RepositoryOption) *UserRepo {
 			Id:    goqu.C("id").Table(t),
 			Name:  goqu.C("name").Table(t),
 			Email: goqu.C("email").Table(t),
+		},
+		c: userRepoColumns{
+			Id:    "id",
+			Name:  "name",
+			Email: "email",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,
@@ -83,6 +97,11 @@ func UserRepoWithInstance(inst *sqlx.DB, opt ...RepositoryOption) *UserRepo {
 			Id:    goqu.C("id").Table(t),
 			Name:  goqu.C("name").Table(t),
 			Email: goqu.C("email").Table(t),
+		},
+		c: userRepoColumns{
+			Id:    "id",
+			Name:  "name",
+			Email: "email",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,

--- a/examples/example3/adapters/mysql/account_repo.go
+++ b/examples/example3/adapters/mysql/account_repo.go
@@ -23,15 +23,24 @@ type (
 		dialectName string
 		options     RepositoryOpt
 
-		// short for "table"
+		// Short for "table".
 		t string
-		// short for "table fields"
+		// Short for "table fields", holds repository model fields as goqu exp.IdentifierExpression.
 		f accountRepoFields
+		// Short for "table columns", holds repository model columns as string.
+		//
+		// Helps to write goqu.UpdateDataset with goqu.Record{}.
+		c accountRepoColumns
 	}
 	accountRepoFields struct {
 		UserId       exp.IdentifierExpression
 		Login        exp.IdentifierExpression
 		PasswordHash exp.IdentifierExpression
+	}
+	accountRepoColumns struct {
+		UserId       string
+		Login        string
+		PasswordHash string
 	}
 )
 
@@ -55,6 +64,11 @@ func NewAccountRepo(dsn string, opt ...RepositoryOption) *AccountRepo {
 			UserId:       goqu.C("user_id").Table(t),
 			Login:        goqu.C("login").Table(t),
 			PasswordHash: goqu.C("pass").Table(t),
+		},
+		c: accountRepoColumns{
+			UserId:       "user_id",
+			Login:        "login",
+			PasswordHash: "pass",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,
@@ -83,6 +97,11 @@ func AccountRepoWithInstance(inst *sqlx.DB, opt ...RepositoryOption) *AccountRep
 			UserId:       goqu.C("user_id").Table(t),
 			Login:        goqu.C("login").Table(t),
 			PasswordHash: goqu.C("pass").Table(t),
+		},
+		c: accountRepoColumns{
+			UserId:       "user_id",
+			Login:        "login",
+			PasswordHash: "pass",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,

--- a/examples/example3/adapters/mysql/user_public_fields_repo.go
+++ b/examples/example3/adapters/mysql/user_public_fields_repo.go
@@ -23,14 +23,22 @@ type (
 		dialectName string
 		options     RepositoryOpt
 
-		// short for "table"
+		// Short for "table".
 		t string
-		// short for "table fields"
+		// Short for "table fields", holds repository model fields as goqu exp.IdentifierExpression.
 		f userPublicFieldsRepoFields
+		// Short for "table columns", holds repository model columns as string.
+		//
+		// Helps to write goqu.UpdateDataset with goqu.Record{}.
+		c userPublicFieldsRepoColumns
 	}
 	userPublicFieldsRepoFields struct {
 		Id   exp.IdentifierExpression
 		Name exp.IdentifierExpression
+	}
+	userPublicFieldsRepoColumns struct {
+		Id   string
+		Name string
 	}
 )
 
@@ -53,6 +61,10 @@ func NewUserPublicFieldsRepo(dsn string, opt ...RepositoryOption) *UserPublicFie
 		f: userPublicFieldsRepoFields{
 			Id:   goqu.C("id").Table(t),
 			Name: goqu.C("name").Table(t),
+		},
+		c: userPublicFieldsRepoColumns{
+			Id:   "id",
+			Name: "name",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,
@@ -80,6 +92,10 @@ func UserPublicFieldsRepoWithInstance(inst *sqlx.DB, opt ...RepositoryOption) *U
 		f: userPublicFieldsRepoFields{
 			Id:   goqu.C("id").Table(t),
 			Name: goqu.C("name").Table(t),
+		},
+		c: userPublicFieldsRepoColumns{
+			Id:   "id",
+			Name: "name",
 		},
 		options: RepositoryOpt{
 			TxGetter: GetTxFromContext,


### PR DESCRIPTION
Generator now generates repo field `c` with strings struct, which comes handy for `gogu.UpdateDataset` operations due to goqu `exp.IdentifierExpression` can not be used as `goqu.Record` map key.